### PR TITLE
Don't display rows where qgroup is not associated with a path

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,30 +5,32 @@ List BTRFS subvolume space use information similar to `df -h` with paths display
 Normally, `btrfs qgroup show` lists subvolumes, but only by id:
 
 ```
+$ btrfs qgroup show /mnt/somebtrfsvol --human-readable --sort=-excl
+
 qgroupid         rfer         excl
 --------         ----         ----
-0/259       107.56GiB    107.56GiB
 0/2317      848.55GiB     24.35GiB
 0/3217      883.62GiB     16.04GiB
 0/1998      840.20GiB     16.01GiB
 0/489       160.81GiB      8.01GiB
-0/5137      146.49GiB      2.06GiB
-0/5083      145.47GiB    999.45MiB
+0/7125      227.62GiB      2.21GiB
+0/7202      230.20GiB    982.49MiB
 ```
 
 This script saves looking up path information with `btrfs subvolume list` as paths
 are included added the output:
 
 ```
+$ ./btrfs-subvolumes.py /mnt/somebtrfsvol --human-readable --sort=-excl
+
 path                                        qgroupid         rfer         excl
 ----                                        --------         ----         ----
-???                                         0/259       107.56GiB    107.56GiB
-backup/timemachine.20160427                 0/2317      848.55GiB     24.35GiB
-Photos/Photos.20160703                      0/3217      883.62GiB     16.04GiB
-Photos/Photos.20161106                      0/1998      840.20GiB     16.01GiB
-Photos/Photos.20160605                      0/489       160.81GiB      8.01GiB
-Archive/Archive.20160504                    0/5137      146.49GiB      2.06GiB
-timemachine/timemachine.20170204            0/5083      145.47GiB    999.45MiB
+Photos/Photos.20160703                      0/2317      848.55GiB     24.35GiB
+Photos/Photos.20161106                      0/3217      883.62GiB     16.04GiB
+Photos/Photos.20160605                      0/1998      840.20GiB     16.01GiB
+Archive/Archive.20160504                    0/489       160.81GiB      8.01GiB
+timemachine/timemachine.20170716            0/7125      227.62GiB      2.21GiB
+timemachine/timemachine.20170723            0/7202      230.20GiB    982.49MiB
 ```
 
 ## Usage

--- a/btrfs-subvolumes.py
+++ b/btrfs-subvolumes.py
@@ -126,4 +126,8 @@ column_width = len(max(path_column, key=len)) + 2
 
 # Output data with extra column for path
 for index,line in enumerate(output):
+    if path_column[index] is "":
+        # We can't print anything useful for qgroups that aren't associated with a path
+        continue
+
     print(path_column[index].ljust(column_width) + output[index])


### PR DESCRIPTION
`btrfs qgroups show` prints all qgroups, including those that are not associated with a subvolume currently. In the context of this script, these rows are essentially unwanted noise:

    ???           0/4787          0.00B        0.00B
    ???           0/4788          0.00B        0.00B
    /useful/path  0/4789       64.79GiB     16.00KiB
    ???           0/4790          0.00B        0.00B
    ???           0/4791          0.00B        0.00B
    ???           0/4792          0.00B        0.00B
